### PR TITLE
no uppercase in package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Scalr/fatmouse-phpclient",
+    "name": "scalr/fatmouse-phpclient",
     "version": "0.0.1",
     "type": "library",
     "description": "Fatmouse PHP Client",


### PR DESCRIPTION
The package name Scalr/fatmouse-phpclient is invalid, it should not contain uppercase characters. We suggest using scalr/fatmouse-phpclient instead.